### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Saffron
+# Saffron
 [![Build Status](https://travis-ci.org/colindresj/saffron.svg?branch=v0.2.2)](https://travis-ci.org/colindresj/saffron)
 [![Gem Version](https://badge.fury.io/rb/saffron.svg)](http://badge.fury.io/rb/saffron)
 
@@ -7,11 +7,11 @@
 Saffron is a collection of Sass mixins and helpers that make adding CSS3 animations and transitions much simpler.
 Just include a mixin in your Sass declaration, then set any configuration using variables and mixin parameters.
 
-###Requirements
+### Requirements
 Sass 3.2+
 
-##Installing
-###Standard Installation
+## Installing
+### Standard Installation
 Install the gem from the command line with `gem install saffron`, then `cd` into the directory where you want to install Saffron and run the installation command:
 ```bash
 saffron install
@@ -25,7 +25,7 @@ Finally, import the mixins into your main SCSS file:
   @import "saffron/saffron";
 ```
 
-###Rails
+### Rails
 If you're using Rails 3.1+, you can add Saffron to your Gemfile:
 ```ruby
   gem "saffron"
@@ -35,11 +35,11 @@ Run `bundle install` to make all the mixins available to your Rails application,
 @import "saffron";
 ```
 
-###Bower
+### Bower
 Saffron is available on [Bower](http://bower.io/). Run `bower install saffron` to get the latest tagged version of Saffron
 from Bower. Unless you've changed the default directory, Saffron will be installed into your `bower_componenents` directory within the `saffron` subdirectory.
 
-###Manual Installation
+### Manual Installation
 Download or clone the project repo from GitHub. Copy the `saffron` folder and paste into your `sass` folder (or whatever you call it). You won't need any of the other directories or files.
 ```scss
   @import "saffron/saffron";
@@ -51,7 +51,7 @@ No matter how you installed Saffron, you can now use any of the mixins:
   }
 ```
 
-##Updating
+## Updating
 To get the latest mixins you should update the Saffron files every once in a while. You can do so by running:
 ```bash
 saffron update
@@ -61,13 +61,13 @@ If you initially installed Saffron in a specific directory using the `-p` flag, 
 saffron update -p path/to/directory/
 ```
 
-##Browser Support
+## Browser Support
 Saffron uses CSS3 transform, keyframes, animations and transitions, so it's really only for modern browsers. Visit http://caniuse.com/ for a clear idea of CSS3 browser support.
 
 All the mixins compile down to vendor prefixed CSS, and have been tested on the latest versions of Chrome, Safari, Firefox and Opera. I aim to do more browser testing and hope to increase compatability, especially for IE.
 
-##Stylus
+## Stylus
 If you're more of a Stylus user, check out [@willhoag](https://github.com/willhoag)'s port: [Saffron-Stylus](https://github.com/willhoag/saffron-stylus).
 
-##License
+## License
 MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
